### PR TITLE
fix(deps): replace broken mem0 source with mem0ai

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ test = [
     "pytest-mock>=3.12.0",
 ]
 memory = [
-    "mem0 @ git+https://github.com/supermemory-ai/mem0.git",
+    "mem0ai>=1.0.5",
 ]
 all = [
     "debugpy",
@@ -76,7 +76,7 @@ all = [
     "pytest-mock>=3.12.0",
     "black>=23.0.0",
     "ruff>=0.1.0",
-    "mem0 @ git+https://github.com/supermemory-ai/mem0.git",
+    "mem0ai>=1.0.5",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,5 +24,5 @@ agent-dev-cli
 # MCP server runtime for Copilot tool registration
 mcp[cli]>=1.6.0,<2.0.0
 
-# Supermemory (mem0) for enhanced memory capabilities
-git+https://github.com/supermemory-ai/mem0.git
+# Mem0 package for enhanced memory capabilities
+mem0ai>=1.0.5


### PR DESCRIPTION
## Why
The MCP startup command documented in README failed because dependency resolution tried to fetch:

- `git+https://github.com/supermemory-ai/mem0.git` (repository no longer exists)

This broke:

`uv run --prerelease=allow --with "mcp[cli]>=1.6.0,<2.0.0" --with-requirements requirements.txt mcp run mcp_server.py`

## What changed
- Updated `requirements.txt`:
  - from `git+https://github.com/supermemory-ai/mem0.git`
  - to `mem0ai>=1.0.5`
- Updated `pyproject.toml` optional dependency groups:
  - `memory`: now `mem0ai>=1.0.5`
  - `all`: now `mem0ai>=1.0.5`

## Validation
Ran from repo root:

```bash
uv run --prerelease=allow --with "mcp[cli]>=1.6.0,<2.0.0" --with-requirements requirements.txt mcp --help
```

Result: command succeeds and displays MCP CLI help (no fetch failure).
